### PR TITLE
Change needed to display the documentation in ReadTheDocs

### DIFF
--- a/CCPPtechnical/requirements.txt
+++ b/CCPPtechnical/requirements.txt
@@ -1,0 +1,1 @@
+sphinxcontrib-bibtex


### PR DESCRIPTION
In order to display the CCPP TechDoc in ReadTheDocs, it is necessary to add a requirements.txt file specifying that bibtex is required. This was tested by displaying the documentation in my fork (successful).