### PR TITLE
sphinxcontrib-bibtex has been upgraded to 2.0.0 as of 12 Dec 2020.

### DIFF
--- a/CCPPtechnical/source/conf.py
+++ b/CCPPtechnical/source/conf.py
@@ -54,6 +54,8 @@ extensions = [
     'sphinxcontrib.bibtex'
 ]
 
+bibtex_bibfiles = ['references.bib']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
This requires bibtex_bibfiles to be set in conf.py for ReadTheDocs to build
the documentation.

Both HTML and PDF builds succeeded.