### PR TITLE
master:  sphinxcontrib-bibtex has been upgraded to 2.0.0 as of 12 Dec 2020.

### DIFF
--- a/CCPPtechnical/source/HostSideCoding.rst
+++ b/CCPPtechnical/source/HostSideCoding.rst
@@ -320,6 +320,7 @@ The ``cdata`` structure is used for holding five variables that must always be a
 .. _MandatoryVariables:
 
 .. code-block:: fortran
+
   [ccpp-table-properties]
     name = ccpp_types
     type = module

--- a/CCPPtechnical/source/conf.py
+++ b/CCPPtechnical/source/conf.py
@@ -54,6 +54,8 @@ extensions = [
     'sphinxcontrib.bibtex'
 ]
 
+bibtex_bibfiles = ['references.bib']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
This requires bibtex_bibfiles to be set in conf.py for ReadTheDocs to build
the documentation.

Fix Error in "code-block" directive: in HostSideCoding.rst.

Both HTML and PDF builds succeeded.