### PR TITLE
Clean up and documentation for phases timestep_init and timestep_finalize

### DIFF
--- a/CCPPtechnical/source/CCPPPreBuild.rst
+++ b/CCPPtechnical/source/CCPPPreBuild.rst
@@ -5,11 +5,11 @@ Technical Aspects of the CCPP *Prebuild*
 **************************************************
 
 =============================
-*Prebuild* Script Function  
+*Prebuild* Script Function
 =============================
 
 The :term:`CCPP` *prebuild* script ``ccpp/framework/scripts/ccpp_prebuild.py`` is the central piece of code that
-connects the host model with the :term:`CCPP-Physics` schemes (see :numref:`%s <ccpp_static_build>`). This script must be run 
+connects the host model with the :term:`CCPP-Physics` schemes (see :numref:`%s <ccpp_static_build>`). This script must be run
 before compiling the :term:`CCPP-Physics` library and the host model cap. This may be done manually or as part
 of a host model build-time script. In the case of the SCM, ``ccpp_prebuild.py`` must be run manually, as it not
 incorporated in that model’s build system. In the case of ufs-weather-model, ``ccpp_prebuild.py`` can be run manually
@@ -22,7 +22,7 @@ on the host model side and from the individual physics schemes (``.meta`` files;
 
  * Compiles a list of variables provided by the host model.
 
- * Matches these variables by their ``standard_name``, checks for missing variables and mismatches of their 
+ * Matches these variables by their ``standard_name``, checks for missing variables and mismatches of their
    attributes (e.g., units, rank, type, kind) and processes information on optional variables. Performs
    automatic unit conversions if a mismatch of units is detected between a scheme and the host model
    (see :numref:`Section %s <AutomaticUnitConversions>` for details).
@@ -34,7 +34,7 @@ on the host model side and from the individual physics schemes (``.meta`` files;
     * The script generates caps for the suite as a whole and physics groups as defined in the input
       :term:`SDF`\s; in addition, the :term:`CCPP` API for the build is generated.
 
- * Populates makefiles with caps. Statements to compile the :term:`CCPP` API are included as well. 
+ * Populates makefiles with caps. Statements to compile the :term:`CCPP` API are included as well.
 
 .. _ccpp_prebuild:
 
@@ -111,10 +111,10 @@ To connect the :term:`CCPP` with a host model ``XYZ``, a Python-based configurat
 Although most of the variables in the ``ccpp_prebuild_config.py`` script are described by in-line comments in the code listing above and their use is described in :numref:`Figure %s <ccpp_prebuild>`, some clarifying comments are in order regarding the ``SCHEME_FILES`` variable. This is a list of CCPP-compliant physics scheme entry/exit point source files. For each item in this list, a list of physics “sets” in which the scheme may be executed is included. A physics set refers to a collection of physics schemes that are able to be called together and executed in one software domain of a host model that do not share variables with schemes from another physics set. This feature was included to cater to the needs of the :term:`UFS Weather Model`, which provides a clear-cut example of this concept. In this model, part of the microphysics scheme needed to be coupled more tightly with the dynamics, so this part of the microphysics code was put into a physics set labeled “fast_physics” which is executed within the dycore code. The variables in this physics set are distinct (in memory, due to a lack of a model variable registry) from variables used in the rest of the physics, which are part of the “slow_physics” set. In the future, it may be necessary to have additional sets, e.g. for chemistry or separate surface model components that do not share data/memory with other model components. For simpler models such as the CCPP SCM, only one physics set (labeled “physics”) is necessary. The concept of physics sets is different from physics “groups”, which are capable of sharing variables among their members and between groups but are used to organize schemes into sequential, callable units.
 
 =============================
-Running ccpp_prebuild.py 
+Running ccpp_prebuild.py
 =============================
 
-Once the configuration in ``ccpp_prebuild_config.py`` is complete, the ``ccpp_prebuild.py`` script can be run from the top level directory. For the SCM, this script must be run to reconcile data provided by the SCM with data required by the physics schemes before compilation and to generate physics caps and makefile segments. For the :term:`UFS` Atmosphere host model, the ``ccpp_prebuild.py`` script is called automatically by the ufs-weather-model build system when the :term:`CCPP` build is requested (by running the :term:`CCPP` regression tests or by passing the option CCPP=Y and others to the ``compile.sh`` script; see the compile commands defined in the :term:`CCPP` regression test configurations for further details). 
+Once the configuration in ``ccpp_prebuild_config.py`` is complete, the ``ccpp_prebuild.py`` script can be run from the top level directory. For the SCM, this script must be run to reconcile data provided by the SCM with data required by the physics schemes before compilation and to generate physics caps and makefile segments. For the :term:`UFS` Atmosphere host model, the ``ccpp_prebuild.py`` script is called automatically by the ufs-weather-model build system when the :term:`CCPP` build is requested (by running the :term:`CCPP` regression tests or by passing the option CCPP=Y and others to the ``compile.sh`` script; see the compile commands defined in the :term:`CCPP` regression test configurations for further details).
 
 For developers adding a CCPP-compliant physics scheme, running ``ccpp_prebuild.py`` periodically is recommended to check that the metadata provided with the physics schemes matches what the host model provided. For the :term:`UFS` Atmosphere, running ``ccpp_prebuild.py`` manually is identical to running it for the SCM (since the relative paths to their respective ``ccpp_prebuild_config.py`` files are identical), except it may be necessary to add the ``--suites`` command-line argument.
 
@@ -125,7 +125,7 @@ As alluded to above, the ``ccpp_prebuild.py`` script has five command line optio
  |  ``--clean``            remove files created by this script, then exit
  |  ``--debug``            enable debugging output
  |  ``--suites`` SUITES    SDF(s) to use (comma-separated, without path)
- 
+
 .. note::
 
    If the --suites option is omitted, all suites will be compiled into the executable.
@@ -138,7 +138,7 @@ An example invocation of running the script (called from the host model’s top 
      --config=./ccpp/config/ccpp_prebuild_config.py \
      --suites=FV3_GFS_v15p2 \
      --debug
- 
+
 which uses a configuration script located at the specified path. The debug option can be used for more verbose output from the script.
 
 The :term:`SDF`\(s) must be included and specified using the ``--suites`` command-line argument. Such files are included with the SCM and ufs-weather-model repositories, and must be included with the code of any host model to use the :term:`CCPP`\.  An example of a build using two :term:`SDF`\s is:
@@ -146,18 +146,18 @@ The :term:`SDF`\(s) must be included and specified using the ``--suites`` comman
 .. code-block:: console
 
    ./ccpp/framework/scripts/ccpp_prebuild.py \
-     --config=./ccpp/config/ccpp_prebuild_config.py \ 
+     --config=./ccpp/config/ccpp_prebuild_config.py \
      --suites=FV3_GFS_v15p2,FV3_GFS_v16beta
 
 If the :term:`CCPP` *prebuild* step is successful, the last output line will be:
 
 ``INFO: CCPP prebuild step completed successfully.``
- 
+
 To remove all files created by ``ccpp_prebuild.py``, for example as part of a host model’s ``make clean`` functionality, execute the same command as before, but with ``--clean`` appended:
- 
+
 .. code-block:: console
 
-  ./ccpp/framework/scripts/ccpp_prebuild.py --config=./ccpp/config/ccpp_prebuild_config.py \ 
+  ./ccpp/framework/scripts/ccpp_prebuild.py --config=./ccpp/config/ccpp_prebuild_config.py \
   --suites=FV3_GFS_v15p2,FV3_GFS_v16beta --clean
 
 =============================
@@ -170,8 +170,8 @@ If invoking the ``ccpp_prebuild.py`` script fails, some message other than the s
  #. ``ERROR: Configuration file`` erroneous/path/to/config/file ``not found``
       * Check that the path entered for the ``--config`` command line option points to a readable configuration file.
  #. ``KeyError``: 'erroneous_scheme_name' when using the ``--suites`` option
-      * This error indicates that a scheme within the supplied :term:`SDF`\s does not match any scheme names found in the SCHEME_FILES variable of the supplied configuration file that lists scheme source files. Double check that the scheme’s source file is included in the SCHEME_FILES list and that the scheme name that causes the error is spelled correctly in the supplied :term:`SDF`\s and matches what is in the source file (minus any ``*_init``, ``*_run``, ``*_finalize`` suffixes).
- #. ``CRITICAL: Suite definition file`` erroneous/path/to/SDF.xml ``not found``. 
+      * This error indicates that a scheme within the supplied :term:`SDF`\s does not match any scheme names found in the SCHEME_FILES variable of the supplied configuration file that lists scheme source files. Double check that the scheme’s source file is included in the SCHEME_FILES list and that the scheme name that causes the error is spelled correctly in the supplied :term:`SDF`\s and matches what is in the source file (minus any ``*_timestep_init``, ``*_init``, ``*_run``, ``*_finalize``, ``*_timestep_finalize`` suffixes).
+ #. ``CRITICAL: Suite definition file`` erroneous/path/to/SDF.xml ``not found``.
 
     ``Exception: Parsing suite definition file`` erroneous/path/to/SDF.xml ``failed``.
       * Check that the path ``SUITES_DIR`` in the :term:`CCPP` prebuild config and the names entered for the ``--suites`` command line option are correct.
@@ -188,13 +188,13 @@ If invoking the ``ccpp_prebuild.py`` script fails, some message other than the s
     ``IOError: [Errno 2] No such file or directory``: 'erroneous_file.f90'
       * Check that the paths specified in the ``VARIABLE_DEFINITION_FILES`` of the supplied configuration file are valid and contain CCPP-compliant host model snippets for insertion of metadata information. (see :ref:`example <SnippetMetadata>`)
  #. ``Exception: Error parsing variable entry`` "erroneous variable metadata table entry data" ``in argument table`` variable_metadata_table_name
-      * Check that the formatting of the metadata entry described in the error message is OK. 
+      * Check that the formatting of the metadata entry described in the error message is OK.
  #. ``Exception: New entry for variable`` var_name ``in argument table`` variable_metadata_table_name ``is incompatible with existing entry``:
      | ``Existing: Contents of <mkcap.Var object at 0x10299a290> (* = mandatory for compatibility)``:
      |  ``standard_name`` = var_name *
      |  ``long_name``     =
      |  ``units``         = various *
-     |  ``local_name``    = 
+     |  ``local_name``    =
      |  ``type``          = real *
      |  ``rank``          = (:,:,:) *
      |  ``kind``          = kind_phys *
@@ -204,9 +204,9 @@ If invoking the ``ccpp_prebuild.py`` script fails, some message other than the s
      |  ``container``     = MODULE_X TYPE_Y
      | ``vs. new: Contents of <mkcap.Var object at 0x10299a310> (* = mandatory for compatibility)``:
      |  ``standard_name`` = var_name *
-     |  ``long_name``     = 
+     |  ``long_name``     =
      |  ``units``         = frac *
-     |  ``local_name``    = 
+     |  ``local_name``    =
      |  ``type``          = real *
      |  ``rank``          = (:,:) *
      |  ``kind``          = kind_phys *
@@ -217,7 +217,7 @@ If invoking the ``ccpp_prebuild.py`` script fails, some message other than the s
 
      * This error is associated with a variable that is defined more than once (with the same standard name) on the host model side. Information on the offending variables is provided so that one can provide different standard names to the different variables.
  #. ``Exception: Scheme name differs from module name``: ``module_name``\= "X" vs. ``scheme_name``\= "Y"
-      * Make sure that each scheme in the errored module begins with the module name and ends in either ``*_init``, ``*_run``, or ``*_finalize``.
+      * Make sure that each scheme in the errored module begins with the module name and ends in either ``*_timestep_init``, ``*_init``, ``*_run``, ``*_finalize``, or ``*_timestep_finalize``.
  #. ``Exception: Encountered closing statement "end" without descriptor (subroutine, module, ...): line X= "end " in file`` erroneous_file.F90
       * This script expects that subroutines and modules end with descriptor and name, e.g. ‘end subroutine subroutine_name’.
  #. ``Exception: New entry for variable`` var_name ``in argument table of subroutine`` scheme_subroutine_name ``is incompatible with existing entry``:
@@ -225,7 +225,7 @@ If invoking the ``ccpp_prebuild.py`` script fails, some message other than the s
      |  ``standard_name`` = var_name *
      |  ``long_name``     =
      |  ``units``         = various *
-     |  ``local_name``    = 
+     |  ``local_name``    =
      |  ``type``          = real *
      |  ``rank``          = (:,:,:) *
      |  ``kind``          = kind_phys *
@@ -235,9 +235,9 @@ If invoking the ``ccpp_prebuild.py`` script fails, some message other than the s
      |  ``container``     = MODULE_X TYPE_Y
      | ``vs. new: Contents of <mkcap.Var object at 0x10299a310> (* = mandatory for compatibility)``:
      |  ``standard_name`` = var_name *
-     |  ``long_name``     = 
+     |  ``long_name``     =
      |  ``units``         = frac *
-     |  ``local_name``    = 
+     |  ``local_name``    =
      |  ``type``          = real *
      |  ``rank``          = (:,:) *
      |  ``kind``          = kind_phys *
@@ -247,41 +247,41 @@ If invoking the ``ccpp_prebuild.py`` script fails, some message other than the s
      |  ``container``     = MODULE_X TYPE_Y
 
      * This error is associated with physics scheme variable metadata entries that have the same standard name with different mandatory properties (either units, type, rank, or kind currently -- those attributes denoted with a ``*``). This error is distinguished from the error described in 8 above, because the error message mentions “in argument table of subroutine” instead of just “in argument table”.
- #. ``ERROR: Check that all subroutines in module`` module_name ``have the same root name``:
+ #. ``ERROR: Check that all CCPP entry point subroutines in module`` module_name ``have the same root name``:
      ``i.e. scheme_A_init, scheme_A_run, scheme_A_finalize``
      ``Here is a list of the subroutine names for scheme`` scheme_name: scheme_name_finalize, scheme_name_run
      * All schemes must have ``*_init``, ``*_run``, ``*_finalize`` subroutines contained within its entry/exit point module.
  #. ``ERROR: Variable`` X ``requested by MODULE_``\Y ``SCHEME_``\Z ``SUBROUTINE_``\A ``not provided by the model``
      ``Exception: Call to compare_metadata failed.``
 
-     * A variable requested by one or more physics schemes is not being provided by the host model. If the variable exists in the host model but is not being made available for the :term:`CCPP`, an entry must be added to one of the host model variable metadata sections. 
+     * A variable requested by one or more physics schemes is not being provided by the host model. If the variable exists in the host model but is not being made available for the :term:`CCPP`, an entry must be added to one of the host model variable metadata sections.
  #. ``ERROR:   error, variable`` X ``requested by MODULE_``\Y ``SCHEME_``\Z ``SUBROUTINE_``\A ``cannot be identified unambiguously. Multiple definitions in MODULE_``\Y ``TYPE_``\B
       * A variable is defined in the host model variable metadata more than once (with the same standard name). Remove the offending entry or provide a different standard name for one of the duplicates.
  #. ``ERROR:   incompatible entries in metadata for variable`` var_name:
      | ``provided:  Contents of <mkcap.Var object at 0x104883210> (* = mandatory for compatibility)``:
      |  ``standard_name`` = var_name *
-     |  ``long_name``     = 
+     |  ``long_name``     =
      |  ``units``         = K *
-     |  ``local_name``    = 
+     |  ``local_name``    =
      |  ``type``          = real *
      |  ``rank``          =  *
      |  ``kind``          = kind_phys *
      |  ``intent``        = none
      |  ``optional``      = F
      |  ``target``        = None
-     |  ``container``     = 
+     |  ``container``     =
      | ``requested: Contents of <mkcap.Var object at 0x10488ca90> (* = mandatory for compatibility)``:
      |  ``standard_name`` = var_name *
-     |  ``long_name``     = 
+     |  ``long_name``     =
      |  ``units``         = none *
-     |  ``local_name``    = 
+     |  ``local_name``    =
      |  ``type``          = real *
      |  ``rank``          =  *
      |  ``kind``          = kind_phys *
      |  ``intent``        = in
      |  ``optional``      = F
      |  ``target``        = None
-     |  ``container``     = 
+     |  ``container``     =
  #. ``Exception: Call to compare_metadata failed``.
       * This error indicates a mismatch between the attributes of a variable provided by the host model and what is requested by the physics. Specifically, the units, type, rank, or kind don’t match for a given variable standard name. Double-check that the attributes for the provided and requested mismatched variable are accurate. If after checking the attributes are indeed mismatched, reconcile as appropriate (by adopting the correct variable attributes either on the host or physics side).
 

--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -23,7 +23,7 @@ discouraged, that is, it is preferable that the CCPP be composed of atomic param
 example is the implementation of the MG microphysics, in which a simple entry point
 leads to two versions of the scheme, MG2 and MG3.  A cleaner implementation would be to retire MG2
 in favor of MG3, to put MG2 and MG3 as separate schemes, or to create a single scheme that can behave
-as MG2 nd MG3 depending on namelist options.
+as MG2 and MG3 depending on namelist options.
 
 The implementation of a driver is reasonable under the following circumstances:
 
@@ -31,20 +31,31 @@ The implementation of a driver is reasonable under the following circumstances:
   microphysics scheme is distributed both with the Weather Research and Forecasting (WRF) model
   and with the CCPP. Having a driver with CCPP directives allows the Thompson scheme to remain
   intact so that it can be synchronized between the WRF model and the CCPP distributions. See
-  more in ``mp_thompson_hrrr.F90`` in the ``ccpp-physics/physics`` directory.
+  more in ``mp_thompson.F90`` in the ``ccpp-physics/physics`` directory.
 
 * To deal with optional arguments. A driver can check whether optional arguments have been
   provided by the host model to either write out a message and return an error code or call a
-  subroutine with or without optional arguments. For example, see ``mp_thompson_hrrr.F90``,
-  ``radsw_main.f``, or ``radlw_main.f`` in the ``ccpp-physics/physics`` directory.
+  subroutine with or without optional arguments. For example, see ``mp_thompson.F90``,
+  ``radsw_main.F90``, or ``radlw_main.F90`` in the ``ccpp-physics/physics`` directory.
 
 * To perform unit conversions or array transformations, such as flipping the vertical direction
   and rearranging the index order, for example, ``cu_gf_driver.F90`` in the ``ccpp-physics/physics``
   directory.
 
 Schemes in the CCPP are classified into two categories: primary schemes and interstitial schemes.
-Primary schemes are the major parameterizations, such as PBL, microphysics, convection, radiation,
-surface layer parameterizations, etc. Interstitial schemes are modularized pieces of code that
+A primary scheme is one that updates the state variables and tracers or that
+produces tendencies for updating state variables and tracers based on the
+representation of major physical processes, such as radiation, convection,
+microphysics, etc. Exclusions are:
+
+* Schemes that compute tendencies exclusively for diagnostic purposes.
+
+* Schemes that adjust tendencies for different timesteps (e.g., create radiation
+  tendencies based on a radiation scheme called at coarser intervals).
+
+* Schemes that update the model state based on tendencies generated in primary schemes.
+
+Interstitial schemes are modularized pieces of code that
 perform data preparation, diagnostics, or other “glue” functions and allow primary schemes to work
 together as a suite. They can be categorized as “scheme-specific” or “suite-level”. Scheme-specific
 interstitial schemes augment a specific primary scheme (to provide additional functionality).
@@ -59,31 +70,37 @@ General Rules
 =============
 A CCPP-compliant scheme is in the form of Fortran modules. :ref:`Listing 2.1 <scheme_template>` contains
 the template for a CCPP-compliant scheme (``ccpp/framework/doc/DevelopersGuide/scheme_template.F90``),
-which includes three essential components: the *_init*, *_run*, and *_finalize* subroutines. Each ``.f`` or ``.F90``
+which includes at least one of these five components: the *_timestep_init*, *_init*,
+*_run*, *_finalize*, and *_timestep_finalize* subroutines. Each ``.f`` or ``.F90``
 file that contains an entry point(s) for CCPP scheme(s) must be accompanied by a .meta file in the same directory
 as described in :numref:`Section %s <MetadataRules>`
 
 .. _scheme_template:
 .. literalinclude:: ./_static/scheme_template.F90
    :language: fortran
-   :lines: 85-129
+   :lines: 10-48
 
-*Listing 2.1: Fortran template for a CCPP-compliant scheme showing the _init, _run, and _finalize subroutines.*
+*Listing 2.1: Fortran template for a CCPP-compliant scheme showing the _run subroutine. The structure for the other phases (_timestep_init, _init, _finalize, and _timestep_finalize is identical.*
 
 More details are found below:
 
-* Each scheme must be in its own module and must include three (*_init*, *_run*, and *_finalize*)
-  subroutines (entry points). The module name and the subroutine names must be consistent with the
-  scheme name. The *_init* and *_finalize* subroutines are run automatically when the CCPP-Physics
-  are initialized and finalized, respectively. These two subroutines may be called more than once,
-  depending on the host model’s parallelization strategy, and as such must be idempotent (the answer
-  must be the same when the subroutine is called multiple times). The _run subroutine contains the
-  code to execute the scheme.
+* Each scheme must be in its own module and must include at least one of the
+  following subroutines (entry points): *_timestep_init*, *_init*, *_run*, *_finalize*,
+  and *_timestep_finalize*. The module name and the subroutine names must be consistent with the
+  scheme name. The *_run* subroutine contains the
+  code to execute the scheme. If subroutines *_timestep_init* or *_timestep_finalize* are present,
+  they will be executed at the beginning and at the end of the host model physics timestep,
+  respectively. If present, the *_init* and *_finalize* subroutines
+  associated with a scheme are run before and after the *_run* phase of the scheme.
+  The *_init* and *_finalize* phases can be used even if the *_run* phase if absent.
+  The *_init* and *_finalize* subroutines may be called more than once depending
+  on the host model’s parallelization strategy, and as such must be idempotent (the answer
+  must be the same when the subroutine is called multiple times).
 
 * Each ``.f`` or ``.F90`` file with one or more CCPP entry point schemes must be accompanied by a a ``.meta`` file containing
   metadata about the arguments to the scheme(s). For more information, see :numref:`Section %s <MetadataRules>`.
 
-* Non-empty schemes must be preceded by the three lines below. These are markup comments used by Doxygen,
+* All schemes must be preceded by the three lines below. These are markup comments used by Doxygen,
   the software employed to create the scientific documentation, to insert an external file containing metadata
   information (in this case, ``schemename_run.html``) in the documentation. See more on this topic in
   :numref:`Section %s <SciDoc>`.
@@ -98,7 +115,7 @@ More details are found below:
   such as  ``‘use EXTERNAL_MODULE’`` should not be used for passing in data and all physical constants
   should go through the argument list.
 
-* Note that standard names, variable names, module names, scheme names and subroutine names are all case sensitive.
+* Note that standard names, variable names, module names, scheme names and subroutine names are all case insensitive.
 
 * Interstitial modules (``scheme_pre`` and ``scheme_post``) can be included if any part of the physics
   scheme must be executed before (``_pre``) or after (``_post``) the ``module scheme`` defined above.
@@ -115,6 +132,9 @@ that contains information about CCPP entry point schemes and their dependencies.
 contain two types of metadata tables: ``ccpp-table-properties`` and ``ccpp-arg-table``, both of which are mandatory.
 The contents of these tables are described in the sections below.
 
+Metadata files (``.meta``) are in a relaxed config file format and contain metadata
+for one or more CCPP entry point schemes.
+
 ccpp-table-properties
 ---------------------
 The ``[ccpp-table-properties]`` section is required in every metadata file and has four valid entries:
@@ -122,10 +142,11 @@ The ``[ccpp-table-properties]`` section is required in every metadata file and h
 #. ``type``:  In the CCPP Physics, ``type`` can be ``scheme``, ``module``, or ``ddt`` and must match the
    ``type`` in the associated ``[ccpp-arg-table]`` section(s).
 
-#. ``name``:  This depends on the ``type``. For types ``ddt`` and ``module`` (for 
+#. ``name``:  This depends on the ``type``. For types ``ddt`` and ``module`` (for
    variable/type/kind definitions), ``name`` must match the name of the **single** associated
    ``[ccpp-arg-table]`` section. For type ``scheme``, the name must match the root names of the
-   ``[ccpp-arg-table]`` sections for that scheme, without the suffixes ``_init``, ``_run``, ``_finalize``.
+   ``[ccpp-arg-table]`` sections for that scheme, without the suffixes
+   ``_timestep_init``,``_init``, ``_run``, ``_finalize``, or ``_timestep_finalize``.
 
 #. ``dependencies``: type/kind/variable definitions and physics schemes often depend on code in other files
    (e.g. "use machine" --> depends on machine.F). These dependencies must be listed in a comma-separated list.
@@ -151,7 +172,7 @@ An example for type and variable definitions in ``GFS_typedefs.meta`` is shown i
    [ccpp-table-properties]
      name = GFS_statein_type
      type = ddt
-     dependencies = 
+     dependencies =
 
    [ccpp-arg-table]
      name = GFS_statein_type
@@ -163,7 +184,7 @@ An example for type and variable definitions in ``GFS_typedefs.meta`` is shown i
    [ccpp-table-properties]
      name = GFS_stateout_type
      type = ddt
-     dependencies = 
+     dependencies =
 
    [ccpp-arg-table]
      name = GFS_stateout_type
@@ -211,8 +232,8 @@ An example metadata file for the CCPP scheme ``mp_thompson.meta`` is shown in :r
 
    ########################################################################
    [ccpp-arg-table]
-     name = mp_thompson_init
-     type = scheme
+    name = mp_thompson_init
+    type = scheme
    ...
 
    ########################################################################
@@ -228,14 +249,13 @@ An example metadata file for the CCPP scheme ``mp_thompson.meta`` is shown in :r
    ...
 
 *Listing 2.3: Example metadata file for a CCPP-compliant physics scheme using a single
-[ccpp-table-properties] and how it defines dependencies for multiple [ccpp-arg-table].*
+[ccpp-table-properties] and how it defines dependencies for multiple [ccpp-arg-table].
+In this example the timestep_init and timestep_finalize phases are not used*
 
 ccpp-arg-table
 --------------
-* Metadata files (``.meta``) are in a relaxed config file format and contain metadata for one or more CCPP entry point schemes.
-  There should be one ``.meta`` file for each ``.f`` or .``F90`` file.
 
-* For each CCPP compliant scheme, the ``.meta`` file should have this set of lines
+For each CCPP compliant scheme, the ``ccpp-arg-table`` should start with this set of lines
 
 .. code-block:: fortran
 
@@ -249,7 +269,7 @@ ccpp-arg-table
 
 * ``<type>`` can be ``scheme``, ``module``, or ``DDT``.
 
-* For empty schemes, the three lines above are sufficient. For non-empty schemes, the metadata must
+* The metadata must
   describe all input and output arguments to the scheme using the following format:
 
 .. code-block:: fortran
@@ -269,7 +289,7 @@ ccpp-arg-table
 
 * The following attributes are optional: ``long_name``, ``kind``, and ``optional``.
 
-* Lines can be combined using | as a separator, e.g.,
+* Lines can be combined using ``|`` as a separator, e.g.,
 
 .. code-block:: console
 
@@ -288,13 +308,15 @@ ccpp-arg-table
    dimensions = (horizontal_dimension,vertical_dimension)
    dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
 
+* The order of arguments in the entry point subroutines must match the order of entries in the metadata file.
+
 * :ref:`Listing 2.4 <meta_template>` contains the template for a CCPP-compliant scheme
   (``ccpp/framework/doc/DevelopersGuide/scheme_template.meta``),
 
 .. _meta_template:
 .. literalinclude:: ./_static/scheme_template.meta
    :language: fortran
-   :lines: 51-81
+   :lines: 10-34
 
 *Listing 2.4: Fortran template for a metadata file accompanying a CCPP-compliant scheme.*
 
@@ -431,16 +453,23 @@ in a physics scheme:
   that the number of OpenMP threads to use is obtained from the host model as an ``intent(in)``
   argument in the argument list (:ref:`Listing 6.2 <MandatoryVariables>`).
 
-* MPI communication is allowed in the ``_init`` and ``_finalize`` phase for the purpose
+* MPI communication is allowed in the ``_timestep_init``, ``_init``, ``_finalize``,
+  and ``_timestep_finalize`` phases for the purpose
   of computing, reading or writing scheme-specific data that is independent of the host
-  model’s data decomposition. An example is the initial read of a lookup table of aerosol
-  properties by one or more MPI processes, and its subsequent broadcast to all processes.
-  Several restrictions apply:
+  model’s data decomposition.
+
+* If MPI is used, it is restricted to global communications: barrier, broadcast,
+  gather, scatter, reduction.
+
+*  An example of a valid use of MPI is the initial read of a lookup table of aerosol
+   properties by one or more MPI processes, and its subsequent broadcast to all processes.
+   Several restrictions apply:
 
    * The implementation of reading and writing of data must be scalable to perform
      efficiently from a few to millions of tasks.
    * The MPI communicator must be provided by the host model as an ``intent(in)``
      argument in the argument list (:ref:`see list of mandatory variables <MandatoryVariables>`).
+   * Point-to-point communication is not allowed.
    * The use of MPI_COMM_WORLD is not allowed.
 
 * Calls to MPI and OpenMP functions, and the import of the MPI and OpenMP libraries,

--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -133,7 +133,7 @@ contain two types of metadata tables: ``ccpp-table-properties`` and ``ccpp-arg-t
 The contents of these tables are described in the sections below.
 
 Metadata files (``.meta``) are in a relaxed config file format and contain metadata
-for one or more CCPP entry point schemes.
+for one or more CCPP entry points.
 
 ccpp-table-properties
 ---------------------
@@ -248,9 +248,9 @@ An example metadata file for the CCPP scheme ``mp_thompson.meta`` is shown in :r
      type = scheme
    ...
 
-*Listing 2.3: Example metadata file for a CCPP-compliant physics scheme using a single
-[ccpp-table-properties] and how it defines dependencies for multiple [ccpp-arg-table].
-In this example the timestep_init and timestep_finalize phases are not used*
+*Listing 2.3: Example metadata file for a CCPP-compliant physics scheme using a single*
+``[ccpp-table-properties]`` *and how it defines dependencies for multiple* ``[ccpp-arg-table]`` *.
+In this example the* ``timestep_init`` *and* ``timestep_finalize`` *phases are not used*.
 
 ccpp-arg-table
 --------------

--- a/CCPPtechnical/source/Overview.rst
+++ b/CCPPtechnical/source/Overview.rst
@@ -77,7 +77,7 @@ and suites to be included and supported. The governance of the CCPP-Framework is
 undertaken by NOAA and NCAR (see more information at https://github.com/NCAR/ccpp-framework/wiki
 and https://dtcenter.org/gmtb/users/ccpp).
 
-The table below lists all parameterizations supported in CCPP and the
+The table below lists all parameterizations supported in CCPP public releases and the
 `CCPP Scientific Documentation <https://dtcenter.ucar.edu/GMTB/v5.0.0/sci_doc>`_
 describes the parameterizations in detail. The parameterizations
 are grouped in suites, which can be classified primarily as operational or experimental.

--- a/CCPPtechnical/source/ScientificDocRules.inc
+++ b/CCPPtechnical/source/ScientificDocRules.inc
@@ -321,11 +321,9 @@ least the following components:
 
   !! \section arg_table_SUBROUTINE_NAME Argument Table
 
-* For subroutines that are non-empty, a second comment indicating that a table
+* A second comment indicating that a table
   of metadata to describe the subroutine arguments will be included from a separate file
-  in HTML format (in this case, file ``SUBROUTINE_NAME.html``). Note that empty
-  subroutines, as is sometimes the case for ``init`` and ``finalize`` subroutines,
-  do not require the inclusion of a file with metadata information.
+  in HTML format (in this case, file ``SUBROUTINE_NAME.html``).
   Please refer to the section below for information on how to generate the HTML files
   with metadata information from the ``.meta`` files.
 
@@ -522,7 +520,7 @@ Including metadata information
 As described above, a table of metadata information should be included in the documentation
 for every CCPP entrypoint scheme. Before doxygen is run, the table for each scheme must be manually
 created in separate
-files in HTML format, with one file per non-empty scheme. The HTML files are included in the
+files in HTML format, with one file per scheme. The HTML files are included in the
 Fortran files using the doygen markup below.
 
 .. code-block:: fortran

--- a/CCPPtechnical/source/_static/scheme_template.F90
+++ b/CCPPtechnical/source/_static/scheme_template.F90
@@ -2,95 +2,14 @@
 ! CCPP-compliant physics scheme template
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
-! General rules:
-!
-! - scheme must be in its own module (module name = scheme name) and must
-!   have three entry points (subroutines) starting with the name of the module:
-!   module scheme_template -> subroutines scheme_template_{init,finalize,run}
-! 
-! - each .f or .F90 file with one or more CCPP entry point schemes must be accompanied by a 
-!   .meta file containing metadata for the scheme(s) 
-!
-! - non-empty schemes must be preceded by the three lines below. These are markup comments used by Doxygen,
-!   the software employed to create the scientific documentation, to insert an external file containing metadata
-!   information (in this case, ``schemename_run.html``) in the documentation. See more on this topic in
-!   the CCPP Technical Documentation available at https://dtcenter.org/community-code/common-community-physics-package-ccpp.
-!
-!   !> \section arg_table_schemename_run Argument Table
-!   !! \htmlinclude schemename_run.html
-!   !!
-!
-! - empty schemes (e.g., scheme_template_init below) do not need metadata
-!
-! - all external information required by the scheme must be passed in via the
-!   argument list, i.e. NO 'use EXTERNAL_MODULE' statements
-!
-! Metadata rules:
-!
-! - refer to file scheme_template.meta for information about the metadata
-!
-! Input/output variable (argument) rules:
-!
-! - for a list of variables available for the specific host model, see files
-!   doc/DevelopersGuide/CCPP_VARIABLES_XYZ.pdf, where XYZ is the name of the model
-!
-! - a standard_name cannot be assigned to more than one local variable (local_name)
-!
-! - all information (units, rank, index ordering) must match the specifications
-!   on the host model side, but subslices can be used/added in the host model:
-!   HOST MODEL: real, dimension(:,:,:,:) :: hydrometeors
-!
-!
-! Coding rules:
-!
-! - code must comply to modern Fortran standards (Fortran 90/95/2003)
-!
-! - use labeled 'end' statements for modules, subroutines and functions
-!   module scheme_template -> end module scheme_template
-!
-! - use implicit none
-!
-! - all intent(out) variables must be initialized properly inside the subroutine
-!
-! - NO permanent state inside the module, i.e. no variables carrying the 'save' attribute
-!
-! - NO 'goto' statements
-!
-! - errors are handled by the host model using the two mandatory arguments
-!   errmsg and errflg; in the event of an error, assign a meaningful error
-!   message to errmsg and set errflg to a value other than 0
-!
-! - schemes are NOT allowed to abort/stop the program
-!
-! - schemes are NOT allowed to perform I/O operations (except for reading
-!   lookup tables / other information needed to initialize the scheme)
-!
-! - line lengths of no more than 120 characters are suggested for better readability
-!
-! Parallel programming rules:
-!
-! - if OpenMP is used, the number of allowed threads must be provided by the
-!   host model as an intent(in) argument in the argument list
-!
-! - if MPI is used, it is restricted to global communications: barrier, broadcast,
-!   gather, scatter, reduction; the MPI communicator must be provided by the
-!   host model as an intent(in) argument in the argument list
-!   - do NOT use MPI_COMM_WORLD
-!   - do NOT use any point-to-point communication
-!
-! - if Fortran coarrays are used, consult with the CCPP development team
+! The general rules for CCPP-compliant physics schemes and metadata are described in file
+! ccpp-doc/CCPPtechnical/source/CompliantPhysicsParams.rst.
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     module scheme_template
 
       contains
-
-      subroutine scheme_template_init ()
-      end subroutine scheme_template_init
-
-      subroutine scheme_template_finalize()
-      end subroutine scheme_template_finalize
 
 !> \section arg_table_scheme_template_run Argument Table
 !! \htmlinclude scheme_template_run.html

--- a/CCPPtechnical/source/_static/scheme_template.meta
+++ b/CCPPtechnical/source/_static/scheme_template.meta
@@ -2,50 +2,8 @@
 ! CCPP-compliant physics scheme template metadata
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
-! Metadata rules:
-!
-! - metadata files (.meta) are in a relaxed config file format and contain metada for one or more CCPP entrypoint schemes. 
-!   There should be one .meta file for each .f or .F90 file
-!
-! - For each CCPP compliant scheme, the .meta file should have this set of lines
-!   [ccpp-arg-table]
-!    name = <name> 
-!    type = <type> 
-!  
-! - ccpp-arg-table indicates the start of a new metadata section for a given scheme
-!
-! - <name> is the name of the corresponding subroutine/module
-!
-! - type can be scheme, module, DDT, or host
-!
-! - for empty schemes, the three lines above are sufficient. For non-empty schemes, the metadata should 
-!   describe all input and output arguments to the scheme using the following format:
-!   [varname]
-!     standard_name = <standard_name> 
-!     long_name = <long_name>
-!     units = <units>
-!     dimensions = <dimensions>
-!     type = <type>
-!     kind =  <kind>
-!     intent = <intent>
-!     optional = <optional>
-!
-! - the intent argument is only valid in scheme metadata tables, as it is not applicable to the other types.
-!
-! - the following attributes are optional: long_name, kind, optional
-!
-! - lines can be combined using | as a separator, e.g., 
-!   type = real | kind = kind_phys
-!
-! - <varname> is the local name of the variable in the subroutine
-!
-! - the dimensions attribute should be empty parentheses for scalars or contain the standard_name for the start and end for 
-!   each dimension of an array. ccpp_constant_one is the assumed start for any dimension which only has a single value.
-!   For example:
-!    dimensions = ()
-!    dimensions = (ccpp_constant_one:horizontal_loop_extent, vertical_level_dimension)
-!    dimensions = (horizontal_dimension,vertical_dimension)
-!    dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
+! The general rules for CCPP-compliant metadata are described in file
+! ccpp-doc/CCPPtechnical/source/CompliantPhysicsParams.rst.
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -54,16 +12,6 @@
   type = scheme
   dependencies = machine.F
 
-[ccpp-arg-table]
-  name = ozphys_init
-  type = scheme
-
-########################################################################
-[ccpp-arg-table]
-  name = ozphys_finalize
-  type = scheme
-
-########################################################################
 [ccpp-arg-table]
   name = ozphys_run
   type = scheme


### PR DESCRIPTION
- Corrected reference to table in Overview (it pertains to CCPP suites supported in _public releases_. 
- scheme_template.F90 and scheme_template.meta: removed rules and instead redirected users to the TechDoc. Removed empty schemes.
- Updated MPI rules with information that was in the scheme_template.F90.
- Included a definition of Primary Scheme.
- Mentioned that standard names are case insensitive.
- Removed references to empty schemes (since we no longer require _init, _run, and _finalize to exist.
- Added documentation for phases timestep_init and timestep_finalize.
- Removed spaces and fixed typos.
- Tested HTML build. OK.