### PR TITLE
horizontal_dimension vs. horizontal_loop_extent, assumed-size arrays

### DIFF
--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -427,7 +427,7 @@ Input/output Variable (argument) Rules
 
   This allows the compiler to perform bounds checking and detect errors that otherwise may go unnoticed.
 
-  **Warning:** Fortran assumes that the lower bound of assumed-size arrays is ``1``. If ``foo`` has lower bounds ``is`` and ``ks`` that are different from ``1``, then these must be specified explicitly:
+  .. warning:: Fortran assumes that the lower bound of assumed-size arrays is ``1``. If ``foo`` has lower bounds ``is`` and ``ks`` that are different from ``1``, then these must be specified explicitly:
 
   .. code-block:: fortran
 

--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -324,22 +324,22 @@ For each CCPP compliant scheme, the ``ccpp-arg-table`` should start with this se
 
 .. _HorizontalDimensionOptionsSchemes:
 
-`horizontal_dimension` vs. `horizontal_loop_extent`
-===================================================
+``horizontal_dimension`` vs. ``horizontal_loop_extent``
+=======================================================
 
 It is important to understand the difference between these metadata dimension names.
 
-* `horizontal_dimension` refers to all (horizontal) grid columns that an MPI process owns/is responsible for, and that are passed to the physics in the `init`, `timestep_init`, `timestep_final`, and `final` phases.
+* ``horizontal_dimension`` refers to all (horizontal) grid columns that an MPI process owns/is responsible for, and that are passed to the physics in the ``init``, ``timestep_init``, ``timestep_final``, and ``final`` phases.
 
-* `horizontal_loop_extent` or, equivalent, `ccpp_constant_one:horizontal_loop_extent` stands for a subset of grid columns that are passed to the physics during the time integration, i.e. in the `run` phase.
+* ``horizontal_loop_extent`` or, equivalent, ``ccpp_constant_one:horizontal_loop_extent`` stands for a subset of grid columns that are passed to the physics during the time integration, i.e. in the ``run`` phase.
 
-* Note that `horizontal_loop_extent` is identical to `horizontal_dimension` for host models that pass all columns to the physics during the time integration.
+* Note that ``horizontal_loop_extent`` is identical to ``horizontal_dimension`` for host models that pass all columns to the physics during the time integration.
 
 Since physics developers cannot know whether a host model is passing all columns to the physics during the time integration or just a subset of it, the following rules apply to all schemes:
 
-* Variables that depend on the horizontal decomposition must use `horizontal_dimension` in the metadata tables for the following phases: `init`, `timestep_init`, `timestep_final`, `final`.
+* Variables that depend on the horizontal decomposition must use ``horizontal_dimension`` in the metadata tables for the following phases: ``init``, ``timestep_init``, ``timestep_final``, ``final``.
 
-* Variables that depend on the horizontal decomposition must use `horizontal_loop_extent` or `ccpp_constant_one:horizontal_loop_extent` in the `run` phase.
+* Variables that depend on the horizontal decomposition must use ``horizontal_loop_extent`` or ``ccpp_constant_one:horizontal_loop_extent`` in the ``run`` phase.
 
 Input/output Variable (argument) Rules
 ======================================

--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -321,6 +321,26 @@ For each CCPP compliant scheme, the ``ccpp-arg-table`` should start with this se
 
 *Listing 2.4: Fortran template for a metadata file accompanying a CCPP-compliant scheme.*
 
+
+.. _HorizontalDimensionOptionsSchemes:
+
+`horizontal_dimension` vs. `horizontal_loop_extent`
+===================================================
+
+It is important to understand the difference between these metadata dimension names.
+
+* `horizontal_dimension` refers to all (horizontal) grid columns that an MPI process owns/is responsible for, and that are passed to the physics in the `init`, `timestep_init`, `timestep_final`, and `final` phases.
+
+* `horizontal_loop_extent` or, equivalent, `ccpp_constant_one:horizontal_loop_extent` stands for a subset of grid columns that are passed to the physics during the time integration, i.e. in the `run` phase.
+
+* Note that `horizontal_loop_extent` is identical to `horizontal_dimension` for host models that pass all columns to the physics during the time integration.
+
+Since physics developers cannot know whether a host model is passing all columns to the physics during the time integration or just a subset of it, the following rules apply to all schemes:
+
+* Variables that depend on the horizontal decomposition must use `horizontal_dimension` in the metadata tables for the following phases: `init`, `timestep_init`, `timestep_final`, `final`.
+
+* Variables that depend on the horizontal decomposition must use `horizontal_loop_extent` or `ccpp_constant_one:horizontal_loop_extent` in the `run` phase.
+
 Input/output Variable (argument) Rules
 ======================================
 

--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -411,9 +411,27 @@ Input/output Variable (argument) Rules
   where necessary. This tactic should be avoided wherever possible, and is not acceptable merely
   as a convenience.
 
-* If a scheme is to make use of CCPP’s subcycling capability, the loop counter can be obtained
-  from CCPP as an ``intent(in)`` variable (see a :ref:`mandatory list of variables <MandatoryVariables>`
-  that are provided by the CCPP-Framework and/or the host model for this and other purposes).
+* If a scheme is to make use of CCPP’s subcycling capability, the current loop counter and the loop extent can be obtained from CCPP as ``intent(in)`` variables (see a :ref:`mandatory list of variables <MandatoryVariables>` that are provided by the CCPP-Framework and/or the host model for this and other purposes).
+
+* It is preferable to use assumed-size array declarations for input/output variables for CCPP schemes, i.e. instead of
+
+  .. code-block:: fortran
+
+     real(kind=kind_phys), dimension(is:ie,ks:ke), intent(inout) :: foo
+
+  one should use
+
+  .. code-block:: fortran
+
+     real(kind=kind_phys), dimension(:,:), intent(inout) :: foo
+
+  This allows the compiler to perform bounds checking and detect errors that otherwise may go unnoticed.
+
+  **Warning:** Fortran assumes that the lower bound of assumed-size arrays is ``1``. If ``foo`` has lower bounds ``is`` and ``ks`` that are different from ``1``, then these must be specified explicitly:
+
+  .. code-block:: fortran
+
+     real(kind=kind_phys), dimension(is:,ks:), intent(inout) :: foo
 
 .. _CodingRules:
 

--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -325,7 +325,7 @@ For each CCPP compliant scheme, the ``ccpp-arg-table`` should start with this se
 .. _HorizontalDimensionOptionsSchemes:
 
 ``horizontal_dimension`` vs. ``horizontal_loop_extent``
-=======================================================
+-------------------------------------------------------
 
 It is important to understand the difference between these metadata dimension names.
 

--- a/CCPPtechnical/source/HostSideCoding.rst
+++ b/CCPPtechnical/source/HostSideCoding.rst
@@ -381,12 +381,13 @@ The CCPP Application Programming Interface (API) is comprised of a set of clearl
 Data Structure to Transfer Variables between Dynamics and Physics 
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 
-The ``cdata`` structure is used for holding five variables that must always be available to the physics schemes. These variables are listed in a metadata table in ``ccpp/framework/src/ccpp_types.meta`` (:ref:`Listing 6.4 <MandatoryVariables>`). 
+The ``cdata`` structure is used for holding six variables that must always be available to the physics schemes. These variables are listed in a metadata table in ``ccpp/framework/src/ccpp_types.meta`` (:ref:`Listing 6.4 <MandatoryVariables>`). 
 
 
 * Error flag for handling in CCPP (``errmsg``).
 * Error message associated with the error flag (``errflg``).
 * Loop counter for subcycling loops (``loop_cnt``).
+* Loop extent for subcycling loops (``loop_max``).
 * Number of block for explicit data blocking in CCPP (``blk_no``).
 * Number of thread for threading in CCPP (``thrd_no``).
 
@@ -437,6 +438,12 @@ The ``cdata`` structure is used for holding five variables that must always be a
     units = index
     dimensions = ()
     type = integer
+  [loop_max]
+    standard_name = ccpp_loop_extent
+    long_name = loop extent for subcycling loops in CCPP
+    units = count
+    dimensions = ()
+    type = integer
   [blk_no]
     standard_name = ccpp_block_number
     long_name = number of block for explicit data blocking in CCPP
@@ -453,11 +460,9 @@ The ``cdata`` structure is used for holding five variables that must always be a
 *Listing 6.4: Mandatory variables provided by the CCPP-Framework from* ``ccpp/framework/src/ccpp_types.meta`` *.
 These variables must not be defined by the host model.*
 
-Two of the variables are mandatory and must be passed to every physics scheme: ``errmsg`` and ``errflg``. The variables ``loop_cnt``, ``blk_no``, and ``thrd_no`` can be passed to the schemes if required, but are not mandatory.  The ``cdata`` structure is only used to hold these five variables, since the host model variables are directly passed to the physics without the need for an intermediate data structure.
+Two of the variables are mandatory and must be passed to every physics scheme: ``errmsg`` and ``errflg``. The variables ``loop_cnt``, ``loop_max``, ``blk_no``, and ``thrd_no`` can be passed to the schemes if required, but are not mandatory.  The ``cdata`` structure is only used to hold these six variables, since the host model variables are directly passed to the physics without the need for an intermediate data structure.
 
 Note that ``cdata`` is not restricted to being a scalar but can be a multidimensional array, depending on the needs of the host model. For example, a model that uses a one-dimensional array of blocks for better cache-reuse may require ``cdata`` to be a one-dimensional array of the same size. Another example of a multi-dimensional array of ``cdata`` is in the SCM, which uses a one-dimensional cdata array for N independent columns. 
-
-Due to a restriction in the Fortran language, there are no standard pointers that are generic pointers, such as the C language allows. The CCPP system therefore has an underlying set of pointers in the C language that are used to point to the original data within the host application cap. The user does not see this C data structure, but deals only with the public face of the Fortran ``cdata`` DDT. The type ``ccpp_t`` is defined in ``ccpp/framework/src/ccpp_types.meta`` and declared in ``ccpp/framework/src/ccpp_types.F90``.
 
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Initializing and Finalizing the CCPP

--- a/CCPPtechnical/source/HostSideCoding.rst
+++ b/CCPPtechnical/source/HostSideCoding.rst
@@ -189,8 +189,9 @@ and :ref:`Listing 6.2 <example_vardefs_meta>` for examples of host model metadat
 
 .. _HorizontalDimensionOptionsHost:
 
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 ``horizontal_dimension`` vs. ``horizontal_loop_extent``
-=======================================================
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 
 Please refer to section :numref:`Section %s <HorizontalDimensionOptionsSchemes>` for a description of the differences between ``horizontal_dimension`` and ``horizontal_loop_extent``. In order to use the correct horizontal dimension, it is necessary to know and understand the data storage model on the host side.
 

--- a/CCPPtechnical/source/HostSideCoding.rst
+++ b/CCPPtechnical/source/HostSideCoding.rst
@@ -189,12 +189,12 @@ and :ref:`Listing 6.2 <example_vardefs_meta>` for examples of host model metadat
 
 .. _HorizontalDimensionOptionsHost:
 
-`horizontal_dimension` vs. `horizontal_loop_extent`
-===================================================
+``horizontal_dimension`` vs. ``horizontal_loop_extent``
+=======================================================
 
-Please refer to section :numref:`Section %s <HorizontalDimensionOptionsSchemes>` for a description of the differences between `horizontal_dimension` and `horizontal_loop_extent`. In order to use the correct horizontal dimension, it is necessary to know and understand the data storage model on the host side.
+Please refer to section :numref:`Section %s <HorizontalDimensionOptionsSchemes>` for a description of the differences between ``horizontal_dimension`` and ``horizontal_loop_extent``. In order to use the correct horizontal dimension, it is necessary to know and understand the data storage model on the host side.
 
-For the examples in listing :ref:`Listing 6.2 <example_vardefs_meta>`, the host model stores all horizontal grid columns of each variable in one contiguous block, therefore `horizontal_dimension` is the correct choice. Alternatively, a host model could store (non-contiguous) blocks of data in an array of DDTs with a length of the total number of blocks, as shown in listing :ref:`Listing 6.3 <example_vardefs_meta_blocked_data>`.
+For the examples in listing :ref:`Listing 6.2 <example_vardefs_meta>`, the host model stores all horizontal grid columns of each variable in one contiguous block, therefore ``horizontal_dimension`` is the correct choice. Alternatively, a host model could store (non-contiguous) blocks of data in an array of DDTs with a length of the total number of blocks, as shown in listing :ref:`Listing 6.3 <example_vardefs_meta_blocked_data>`.
 
 .. _example_vardefs_meta_blocked_data:
 
@@ -223,7 +223,7 @@ For the examples in listing :ref:`Listing 6.2 <example_vardefs_meta>`, the host 
      dimensions = ()
      type = ex_ddt
      kind =
-   [ext(ccpp_block_number)]
+   [ext]
      standard_name = example_ddt_instance_all_blocks
      long_name = ex. ddt inst
      units = DDT

--- a/CCPPtechnical/source/HostSideCoding.rst
+++ b/CCPPtechnical/source/HostSideCoding.rst
@@ -114,14 +114,14 @@ and :ref:`Listing 6.2 <example_vardefs_meta>` for examples of host model metadat
      standard_name = example_ddt
      long_name = ex. ddt
      units = DDT
-     dimensions = (horizontal_dimension,vertical_dimension)
+     dimensions = ()
      type = ex_ddt
      kind =
    [ext]
      standard_name = example_ddt_instance
      long_name = ex. ddt inst
      units = DDT
-     dimensions = (horizontal_dimension,vertical_dimension)
+     dimensions = ()
      type = ex_ddt
      kind =
    [errmsg]
@@ -185,6 +185,78 @@ and :ref:`Listing 6.2 <example_vardefs_meta>` for examples of host model metadat
      kind = kind_phys
 
 *Listing 6.2: Example host model metadata file (* ``.meta`` *).*
+
+
+.. _HorizontalDimensionOptionsHost:
+
+`horizontal_dimension` vs. `horizontal_loop_extent`
+===================================================
+
+Please refer to section :numref:`Section %s <HorizontalDimensionOptionsSchemes>` for a description of the differences between `horizontal_dimension` and `horizontal_loop_extent`. In order to use the correct horizontal dimension, it is necessary to know and understand the data storage model on the host side.
+
+For the examples in listing :ref:`Listing 6.2 <example_vardefs_meta>`, the host model stores all horizontal grid columns of each variable in one contiguous block, therefore `horizontal_dimension` is the correct choice. Alternatively, a host model could store (non-contiguous) blocks of data in an array of DDTs with a length of the total number of blocks, as shown in listing :ref:`Listing 6.3 <example_vardefs_meta_blocked_data>`.
+
+.. _example_vardefs_meta_blocked_data:
+
+.. code-block:: fortran
+
+   ########################################################################
+   [ccpp-table-properties]
+     name = arg_table_example_vardefs
+     type = module
+
+   [ccpp-arg-table]
+     name = arg_table_example_vardefs
+     type = module
+   ...
+   [ex_ddt]
+     standard_name = example_ddt
+     long_name = ex. ddt
+     units = DDT
+     dimensions = ()
+     type = ex_ddt
+     kind =
+   [ext(ccpp_block_number)]
+     standard_name = example_ddt_instance
+     long_name = ex. ddt inst
+     units = DDT
+     dimensions = ()
+     type = ex_ddt
+     kind =
+   [ext(ccpp_block_number)]
+     standard_name = example_ddt_instance_all_blocks
+     long_name = ex. ddt inst
+     units = DDT
+     dimensions = (ccpp_block_count)
+     type = ex_ddt
+     kind =
+   ...
+
+   ########################################################################
+   [ccpp-table-properties]
+     name = arg_table_example_ddt
+     type = ddt
+
+   [ccpp-arg-table]
+     name = arg_table_example_ddt
+     type = ddt
+   [ext%1]
+     standard_name = example_flag
+     long_name = ex. flag
+     units = flag
+     dimensions = 
+     type = logical
+     kind =
+   [ext%r]
+     standard_name = example_real3
+     long_name = ex. real
+     units = kg
+     dimensions = (horizontal_loop_extent,vertical_dimension)
+     type = real
+     kind = r15
+   ...
+
+*Listing 6.3: Example host model metadata file (* ``.meta`` *) for a host model using blocked data structures.*
 
 .. _ActiveAttribute:
 
@@ -308,7 +380,7 @@ The CCPP Application Programming Interface (API) is comprised of a set of clearl
 Data Structure to Transfer Variables between Dynamics and Physics 
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 
-The ``cdata`` structure is used for holding five variables that must always be available to the physics schemes. These variables are listed in a metadata table in ``ccpp/framework/src/ccpp_types.meta`` (:ref:`Listing 6.3 <MandatoryVariables>`). 
+The ``cdata`` structure is used for holding five variables that must always be available to the physics schemes. These variables are listed in a metadata table in ``ccpp/framework/src/ccpp_types.meta`` (:ref:`Listing 6.4 <MandatoryVariables>`). 
 
 
 * Error flag for handling in CCPP (``errmsg``).
@@ -377,7 +449,7 @@ The ``cdata`` structure is used for holding five variables that must always be a
     dimensions = ()
     type = integer
 
-*Listing 6.3: Mandatory variables provided by the CCPP-Framework from* ``ccpp/framework/src/ccpp_types.meta`` *.
+*Listing 6.4: Mandatory variables provided by the CCPP-Framework from* ``ccpp/framework/src/ccpp_types.meta`` *.
 These variables must not be defined by the host model.*
 
 Two of the variables are mandatory and must be passed to every physics scheme: ``errmsg`` and ``errflg``. The variables ``loop_cnt``, ``blk_no``, and ``thrd_no`` can be passed to the schemes if required, but are not mandatory.  The ``cdata`` structure is only used to hold these five variables, since the host model variables are directly passed to the physics without the need for an intermediate data structure.
@@ -495,7 +567,7 @@ The purpose of the host model *cap* is to abstract away the communication betwee
 
 * Providing interfaces to call the CCPP
 
-  * The *cap* must provide functions or subroutines that can be called at the appropriate places in the host model time integration loop and that internally call ``ccpp_init``, ``ccpp_physics_init``, ``ccpp_physics_run``, ``ccpp_physics_finalize`` and ``ccpp_finalize``, and handle any errors returned See :ref:`Listing 6.4 <example_ccpp_host_cap>`. 
+  * The *cap* must provide functions or subroutines that can be called at the appropriate places in the host model time integration loop and that internally call ``ccpp_init``, ``ccpp_physics_init``, ``ccpp_physics_run``, ``ccpp_physics_finalize`` and ``ccpp_finalize``, and handle any errors returned See :ref:`Listing 6.5 <example_ccpp_host_cap>`. 
 
 .. _example_ccpp_host_cap:
 
@@ -568,7 +640,7 @@ The purpose of the host model *cap* is to abstract away the communication betwee
 
  end module example_ccpp_host_cap
 
-*Listing 6.4: Fortran template for a CCPP host model cap from* ``ccpp/framework/doc/DevelopersGuide/host_cap_template.F90``.
+*Listing 6.5: Fortran template for a CCPP host model cap from* ``ccpp/framework/doc/DevelopersGuide/host_cap_template.F90``.
 
 The following sections describe two implementations of host model caps to serve as examples. For each of the functions listed above, a description for how it is implemented in each host model is included.
 

--- a/CCPPtechnical/source/ParamSpecificOutput.rst
+++ b/CCPPtechnical/source/ParamSpecificOutput.rst
@@ -410,14 +410,14 @@ The ``cu_gf_driver.meta`` file was modified accordingly:
    +  standard_name = auxiliary_2d_arrays
    +  long_name = auxiliary 2d arrays to output (for debugging)
    +  units = none
-   +  dimensions = (horizontal_dimension,number_of_3d_auxiliary_arrays)
+   +  dimensions = (horizontal_loop_extent,number_of_3d_auxiliary_arrays)
    +  type = real
    +  kind = kind_phys
    +[aux3d]
    +  standard_name = auxiliary_3d_arrays
    +  long_name = auxiliary 3d arrays to output (for debugging)
    +  units = none
-   +  dimensions = (horizontal_dimension,vertical_dimension,number_of_3d_auxiliary_arrays)
+   +  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_3d_auxiliary_arrays)
    +  type = real
    +  kind = kind_phys
 


### PR DESCRIPTION
- Add documentation for using `horizontal_dimension` and `horizontal_loop_extent` for schemes and host models. Correct bugs in DDT metadata and `aux2d/aux3d` metadata in listings.
- Add instructions for using assumed-size array declarations.
- Add `loop_max` to `ccpp_type` (introduced by PR https://github.com/NCAR/ccpp-framework/pull/376).
- Remove old/invalid text.