### PR TITLE
Update description of metadata argument table rules, prebuild common error messages

### DIFF
--- a/CCPPtechnical/source/AutoGenPhysCaps.rst
+++ b/CCPPtechnical/source/AutoGenPhysCaps.rst
@@ -24,7 +24,7 @@ as arguments to the ``ccpp_prebuild.py`` script.
 The CCPP *prebuild* step performs the tasks below.
 
 * Check requested vs provided variables by ``standard_name``.
-* Check units, rank, type. Perform unit conversions if a mismatch
+* Check units, dimensions, type. Perform unit conversions if a mismatch
   of units is detected and the required conversion has been implemented (see
   :numref:`Section %s <AutomaticUnitConversions>` for details).
 * Filter unused schemes and variables.

--- a/CCPPtechnical/source/CCPPPreBuild.rst
+++ b/CCPPtechnical/source/CCPPPreBuild.rst
@@ -21,7 +21,7 @@ on the host model side and from the individual physics schemes (``.meta`` files;
  * Compiles a list of variables required to run all schemes in the CCPP Physics pool.
 
  * Matches these variables by their ``standard_name``, checks for missing variables and mismatches of their
-   attributes (e.g., units, rank, type, kind). Performs automatic unit conversions if a mismatch of units
+   attributes (e.g., units, dimensions, type, kind). Performs automatic unit conversions if a mismatch of units
    is detected between a scheme and the host model (see :numref:`Section %s <AutomaticUnitConversions>` for details).
 
  * Filters out unused variables for a given :term:`suite`.
@@ -183,110 +183,108 @@ Troubleshooting
 
 If invoking the ``ccpp_prebuild.py`` script fails, some message other than the success message will be written to the terminal output. Specifically, the terminal output will include informational logging messages generated from the script and any error messages written to the Python logging utility. Some common errors (minus the typical logging output and traceback output) and solutions are described below, with non-bold font used to denote aspects of the message that will differ depending on the problem encountered. This is not an exhaustive list of possible errors, however. For example, in this version of the code, there is no cross-checking that the metadata information provided corresponds to the actual Fortran code, so even though ``ccpp_prebuild.py`` may complete successfully, there may be related compilation errors later in the build process. For further help with an undescribed error, you can make a post in the appropriate GitHub discussions forum for *CCPP Physics* (https://github.com/NCAR/ccpp-physics/discussions) or *CCPP Framework* (https://github.com/NCAR/ccpp-framework/discussions).
 
+.. note::
+   Some errors may not cause an immediate failure of the script, causing an exception with very little information at the end such as  ``Exception: Call to compare_metadata failed``. You may need to scroll up substantially to see more information about the error; try searching for the string ``ERROR:`` or ``CRITICAL:``
 
- #. ``ERROR: Configuration file`` erroneous/path/to/config/file ``not found``
-      * Check that the path entered for the ``--config`` command line option points to a readable configuration file.
- #. ``KeyError``: 'erroneous_scheme_name' when using the ``--suites`` option
-      * This error indicates that a scheme within the supplied :term:`SDF`\s does not match any scheme names found in the SCHEME_FILES variable of the supplied configuration file that lists scheme source files. Double check that the scheme’s source file is included in the SCHEME_FILES list and that the scheme name that causes the error is spelled correctly in the supplied SDFs and matches what is in the source file (minus any ``*_timestep_init``, ``*_init``, ``*_run``, ``*_finalize``, ``*_timestep_finalize`` suffixes).
- #. ``CRITICAL: Suite definition file`` erroneous/path/to/SDF.xml ``not found``.
+#. **Problem:** ``ERROR: Configuration file`` `erroneous/path/to/config/file` ``not found``
 
-    ``Exception: Parsing suite definition file`` erroneous/path/to/SDF.xml ``failed``.
-      * Check that the path ``SUITES_DIR`` in the CCPP prebuild config and the names entered for the ``--suites`` command line option are correct.
- #. ``INFO: Parsing metadata tables for variables provided by host model`` …
+   **Solution:** Check that the path entered for the ``--config`` command line option points to a readable configuration file.
 
-    ``IOError: [Errno 2] No such file or directory``: 'erroneous_file.f90'
-      * Check that the paths specified in the ``VARIABLE_DEFINITION_FILES`` of the supplied configuration file are valid and contain CCPP-compliant host model snippets for insertion of metadata information. (see :ref:`example <SnippetMetadata>`)
- #. ``Exception: Error parsing variable entry`` "erroneous variable metadata table entry data" ``in argument table`` variable_metadata_table_name
-      * Check that the formatting of the metadata entry described in the error message is OK.
- #. ``Exception: New entry for variable`` var_name ``in argument table`` variable_metadata_table_name ``is incompatible with existing entry``:
-     | ``Existing: Contents of <mkcap.Var object at 0x10299a290> (* = mandatory for compatibility)``:
-     |  ``standard_name`` = var_name *
-     |  ``long_name``     =
-     |  ``units``         = various *
-     |  ``local_name``    =
-     |  ``type``          = real *
-     |  ``rank``          = (:,:,:) *
-     |  ``kind``          = kind_phys *
-     |  ``intent``        = none
-     |  ``active``        = T
-     |  ``target``        = None
-     |  ``container``     = MODULE_X TYPE_Y
-     | ``vs. new: Contents of <mkcap.Var object at 0x10299a310> (* = mandatory for compatibility)``:
-     |  ``standard_name`` = var_name *
-     |  ``long_name``     =
-     |  ``units``         = frac *
-     |  ``local_name``    =
-     |  ``type``          = real *
-     |  ``rank``          = (:,:) *
-     |  ``kind``          = kind_phys *
-     |  ``intent``        = none
-     |  ``active``        = T
-     |  ``target``        = None
-     |  ``container``     = MODULE_X TYPE_Y
+#. **Problem:** ``CRITICAL: Scheme`` `erroneous_scheme_name` ``in suite`` `suite_name` ``cannot be found``
 
-     * This error is associated with a variable that is defined more than once (with the same :term:`standard name`) on the host model side. Information on the offending variables is provided so that one can provide different standard names to the different variables.
- #. ``Exception: Scheme name differs from module name``: ``module_name``\= "X" vs. ``scheme_name``\= "Y"
-      * Make sure that each scheme in the errored module begins with the module name and ends in either ``*_timestep_init``, ``*_init``, ``*_run``, ``*_finalize``, or ``*_timestep_finalize``.
- #. ``Exception: New entry for variable`` var_name ``in argument table of subroutine`` scheme_subroutine_name ``is incompatible with existing entry``:
-     | ``existing: Contents of <mkcap.Var object at 0x10299a290> (* = mandatory for compatibility)``:
-     |  ``standard_name`` = var_name *
-     |  ``long_name``     =
-     |  ``units``         = various *
-     |  ``local_name``    =
-     |  ``type``          = real *
-     |  ``rank``          = (:,:,:) *
-     |  ``kind``          = kind_phys *
-     |  ``intent``        = none
-     |  ``active``        = T
-     |  ``target``        = None
-     |  ``container``     = MODULE_X TYPE_Y
-     | ``vs. new: Contents of <mkcap.Var object at 0x10299a310> (* = mandatory for compatibility)``:
-     |  ``standard_name`` = var_name *
-     |  ``long_name``     =
-     |  ``units``         = frac *
-     |  ``local_name``    =
-     |  ``type``          = real *
-     |  ``rank``          = (:,:) *
-     |  ``kind``          = kind_phys *
-     |  ``intent``        = none
-     |  ``active``        = T
-     |  ``target``        = None
-     |  ``container``     = MODULE_X TYPE_Y
+   **Solution:** This error indicates that a scheme within the supplied :term:`SDF`\s does not match any scheme names found in the ``SCHEME_FILES`` variable of the supplied configuration file.
+   Double check that:
 
-     * This error is associated with physics scheme variable metadata entries that have the same standard name with different mandatory properties (either units, type, rank, or kind currently -- those attributes denoted with a ``*``). This error is distinguished from the error described in 8 above, because the error message mentions “in argument table of subroutine” instead of just “in argument table”.
- #. ``ERROR: Variable`` X ``requested by MODULE_``\Y ``SCHEME_``\Z ``SUBROUTINE_``\A ``not provided by the model``
-     ``Exception: Call to compare_metadata failed.``
+   - The scheme’s source file is included in the ``SCHEME_FILES`` list.
+   - The scheme name that causes the error is spelled correctly in the supplied SDFs and matches the name in the source file, excluding suffixes like ``*_timestep_init``, ``*_init``, ``*_run``, ``*_finalize``, ``*_timestep_finalize``.
 
-     * A variable requested by one or more physics schemes is not being provided by the host model. If the variable exists in the host model but is not being made available for the CCPP, an entry must be added to one of the host model variable metadata sections.
- #. ``ERROR:   error, variable`` X ``requested by MODULE_``\Y ``SCHEME_``\Z ``SUBROUTINE_``\A ``cannot be identified unambiguously. Multiple definitions in MODULE_``\Y ``TYPE_``\B
-      * A variable is defined in the host model variable metadata more than once (with the same standard name). Remove the offending entry or provide a different standard name for one of the duplicates.
- #. ``ERROR:   incompatible entries in metadata for variable`` var_name:
-     | ``provided:  Contents of <mkcap.Var object at 0x104883210> (* = mandatory for compatibility)``:
-     |  ``standard_name`` = var_name *
-     |  ``long_name``     =
-     |  ``units``         = K *
-     |  ``local_name``    =
-     |  ``type``          = real *
-     |  ``rank``          =  *
-     |  ``kind``          = kind_phys *
-     |  ``intent``        = none
-     |  ``active``        = T
-     |  ``target``        = None
-     |  ``container``     =
-     | ``requested: Contents of <mkcap.Var object at 0x10488ca90> (* = mandatory for compatibility)``:
-     |  ``standard_name`` = var_name *
-     |  ``long_name``     =
-     |  ``units``         = none *
-     |  ``local_name``    =
-     |  ``type``          = real *
-     |  ``rank``          =  *
-     |  ``kind``          = kind_phys *
-     |  ``intent``        = in
-     |  ``active``        = T
-     |  ``target``        = None
-     |  ``container``     =
- #. ``Exception: Call to compare_metadata failed``.
-      * This error indicates a mismatch between the attributes of a variable provided by the host model and what is requested by the physics. Specifically, the units, type, rank, or kind don’t match for a given variable standard name. Double-check that the attributes for the provided and requested mismatched variable are accurate. If after checking the attributes are indeed mismatched, reconcile as appropriate (by adopting the correct variable attributes either on the host or physics side).
+#. **Problem:** ``CRITICAL: Suite definition file`` `erroneous/path/to/SDF.xml` ``not found``
+
+                ``Exception: Parsing suite definition file`` `erroneous/path/to/SDF.xml` ``failed``
+
+   **Solution:**
+   Check that:
+
+   - The path ``SUITES_DIR`` in the CCPP prebuild config is correct.
+   - The names passed to the ``--suites`` command line option are valid.
+
+#. **Problem:** ``INFO: Parsing metadata tables for variables provided by host model``
+
+   ...
+
+   ``IOError: [Errno 2] No such file or directory: '`` `erroneous_file.f90` ``'``
+
+   **Solution:** Check that the paths listed in the ``VARIABLE_DEFINITION_FILES`` section of the configuration file:
+
+   - Are valid and point to existing files.
+   - Contain CCPP-compliant host model snippets for metadata insertion.
+     See example in :ref:`example <SnippetMetadata>`.
+
+#. **Problem:** ``Exception: Error parsing variable entry`` `erroneous variable metadata table entry data` ``in argument table`` `variable_metadata_table_name`
+
+   **Solution:** Check that the formatting of the metadata entry described in the error message is correct
+
+#. **Problem:** ``ERROR: Attempt to add duplicate variable,`` `erroneous variable name` ``from`` `scheme name`
+
+   ``Traceback (most recent call last):``
+
+   ...
+
+   ``parse_source.ParseSyntaxError: Invalid (duplicate) standard name in`` `scheme name` ``, defined at`` `metadata file name and line number` ``, '`` `variable standard name` ``', at`` `metadata file name and line number`
+
+   **Solution:** This error is associated with a variable that is defined more than once (with the same :term:`standard name`) on the host model side. Information on the offending variables is provided so that one can provide different standard names to the different variables.
+
+#. **Problem:** ``ERROR: Variable`` `X` ``requested by MODULE_``\Y ``SCHEME_``\Z ``SUBROUTINE_``\A ``not provided by the model``
+
+   ``Traceback (most recent call last):``
+
+   ...
+
+   ``Exception: Call to compare_metadata failed.``
+
+   **Solution:** A variable requested by one or more physics schemes is not being provided by the host model. If the variable exists in the host model but is not being made available for the CCPP, an entry must be added to one of the host model variable metadata sections.
+
+
+#. **Problem:**
+
+   ::
+
+      ERROR:   incompatible entries in metadata for variable surface_exchange_coefficient_for_heat_at_2m:
+          provided:  Contents of <mkcap.Var object at 0x7f371ac8aa70> (* = mandatory for compatibility):
+                  standard_name = surface_exchange_coefficient_for_heat_at_2m *
+                  long_name     = exchange coefficient for heat at 2 meters
+                  units         = m s-1 *
+                  local_name    = GFS_Sfcprop%chs2
+                  type          = real *
+                  dimensions    = ['ccpp_constant_one:horizontal_dimension']
+                  rank          = (:) *
+                  kind          = kind_phys *
+                  intent        = None
+                  active        = (flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme)
+                  target        = None
+                  container     = MODULE_GFS_typedefs TYPE_GFS_sfcprop_type
+                  actions       = {'in': None, 'out': None}
+          requested: Contents of <mkcap.Var object at 0x7f37195dbb50> (* = mandatory for compatibility):
+                  standard_name = surface_exchange_coefficient_for_heat_at_2m *
+                  long_name     = exchange coefficient for heat at 2 meters
+                  units         = m s-1 *
+                  local_name    = chs2
+                  type          = real *
+                  dimensions    = ['ccpp_constant_one:horizontal_loop_extent', 'ccpp_constant_one:vertical_layer_dimension']
+                  rank          = (:,:) *
+                  kind          = kind_phys *
+                  intent        = inout
+                  optional      = F
+                  target        = None
+                  container     = MODULE_mynnsfc_wrapper SCHEME_mynnsfc_wrapper SUBROUTINE_mynnsfc_wrapper_run
+                  actions       = {'in': None, 'out': None}
+
+   ...
+
+   ``Exception: Call to compare_metadata failed.``
+
+
+   **Solution:** This error indicates a mismatch between the attributes of a variable provided by the host model and what is requested by the physics. Specifically, the units, type, rank, or kind don’t match for a given variable standard name. Double-check that the attributes for the provided and requested mismatched variable are accurate. If after checking the attributes are indeed mismatched, reconcile as appropriate (by adopting the correct variable attributes either on the host or physics side).
 
 Note: One error that the ``ccpp_prebuild.py`` script will not catch is if a physics scheme lists a variable in its actual (Fortran) argument list without a corresponding entry in the subroutine’s variable metadata. This will lead to a compilation error when the autogenerated scheme cap is compiled:
 

--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -306,8 +306,7 @@ For each CCPP compliant scheme, the ``ccpp-arg-table`` for a scheme, module or d
 
 * ``<type>`` can be ``scheme``, ``module``, or ``DDT``.
 
-* The metadata must
-  describe all input and output arguments to the scheme using the following format:
+After the ``ccpp-arg-table``, there should be a metadata entry for every input and output argument to the scheme using the following format. Any attributes that are not listed as optional are required:
 
 .. code-block:: fortran
 
@@ -315,31 +314,31 @@ For each CCPP compliant scheme, the ``ccpp-arg-table`` for a scheme, module or d
     standard_name = <standard_name>
     long_name = <long_name>
     units = <units>
-    rank = <rank>
     dimensions = <dimensions>
     type = <type>
     kind = <kind>
     intent = <intent>
     optional = <True,False>
 
-.. warning::
-   The ``pointer`` attribute is deprecated and no longer allowed in CCPP
-
-* The ``intent`` argument is only valid in ``scheme`` metadata tables, as it is not applicable to the other ``types``.
-
-* The following attributes are optional: ``long_name``, ``kind``, ``optional``.
-
-* Lines can be combined using ``|`` as a separator, e.g.,
-
-.. code-block:: console
-
-   type = real | kind = kind_phys
 
 * ``[varname]`` is the local name of the variable in the subroutine.
 
-* The dimensions attribute should be empty parentheses for scalars or contain the ``standard_name`` for the start and end for
-  each dimension of an array. ``ccpp_constant_one`` is the assumed start for any dimension which only has a single value.
-  For example:
+* ``standard_name`` is the standardized variable name for the given quantity, as specified in the Earth System Modeling Standard Names (https://github.com/ESCOMP/ESMStandardNames)
+
+* ``long_name``  (*optional*) is a human-readable description of the variable contents.
+
+* ``units`` denotes the physical units of the variable quantity. The units should be specified as space-separated SI abbreviations; e.g.
+
+  * ``m2`` meters squared
+  * ``mm s-1`` millimeters per second
+  * ``W m-2`` Watts per meter squared
+  * ``kg m-2 s-1`` kilograms per meter squared per second
+  * For unitless quantities or other variables that do not fit into this categorization, see the `ESM Standard Names documentation <https://github.com/ESCOMP/ESMStandardNames/blob/main/StandardNamesRules.rst#units>`__ for more details
+
+
+.. note:: The ``intent`` argument is only valid in ``scheme`` metadata tables, as it is not applicable to the other ``types``.
+
+* ``dimensions`` indicates the dimensionality of the variable. The dimensions attribute should be empty parentheses for scalars, or indicate the start and end of each dimension of an array with an appropriate standard name; see the `ESM Standard Names documentation <https://github.com/ESCOMP/ESMStandardNames/blob/main/Metadata-standard-names.md#dimensions>`__. ``ccpp_constant_one`` is the assumed start for any dimension which only has a single value. Some examples are listed here:
 
 .. code-block:: fortran
 
@@ -348,17 +347,32 @@ For each CCPP compliant scheme, the ``ccpp-arg-table`` for a scheme, module or d
    dimensions = (horizontal_dimension,vertical_dimension)
    dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
 
-* The order of arguments in the entry point subroutines must match the order of entries in the metadata file.
+* ``type`` indicates the variable type. Can be ``character``, ``integer``, ``real``, or ``logical``.
+
+* ``kind`` (*optional*) indicates the variable kind, i.e. precision. The valid kinds are described in the file `physics/hooks/machine.F <https://github.com/NCAR/ccpp-physics/blob/main/physics/hooks/machine.F>`__.
+
+* ``intent`` indicates the argument intent for the given variable. Can be ``in``, ``out``, or ``inout``.
+
+* ``optional`` (*optional*) indicates whether an argument is optional or not. If omitted, argument is assumed to be required.
+
+* Lines can be combined using ``|`` as a separator, e.g.,
+
+.. code-block:: console
+
+   type = real | kind = kind_phys
+
 
 :ref:`Listing 2.4 <meta_template>` contains the template .meta file for an example CCPP-compliant scheme (``scheme_template.meta``)
 
 .. _meta_template:
 .. literalinclude:: ./_static/scheme_template.meta
    :language: fortran
-   :lines: 10-34
+   :lines: 10-40
 
 *Listing 2.4: Fortran template for a metadata file accompanying a CCPP-compliant scheme.*
 
+.. warning::
+   The ``pointer`` and ``rank`` attributes are deprecated and no longer allowed in CCPP
 
 .. _HorizontalDimensionOptionsSchemes:
 

--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -347,7 +347,7 @@ After the ``ccpp-arg-table``, there should be a metadata entry for every input a
    dimensions = (horizontal_dimension,vertical_dimension)
    dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
 
-* ``type`` indicates the variable type. Can be ``character``, ``integer``, ``real``, or ``logical``.
+* ``type`` indicates the variable type. Can be ``character``, ``integer``, ``real``, ``complex``, ``logical``, ``ddt``, or a custom type defined by the host. Custom types should be listed under ``TYPEDEFS_NEW_METADATA`` in the prebuild configuration file.
 
 * ``kind`` (*optional*) indicates the variable kind, i.e. precision. The valid kinds are described in the file `physics/hooks/machine.F <https://github.com/NCAR/ccpp-physics/blob/main/physics/hooks/machine.F>`__.
 

--- a/CCPPtechnical/source/CompliantPhysicsParams.rst
+++ b/CCPPtechnical/source/CompliantPhysicsParams.rst
@@ -347,9 +347,9 @@ After the ``ccpp-arg-table``, there should be a metadata entry for every input a
    dimensions = (horizontal_dimension,vertical_dimension)
    dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
 
-* ``type`` indicates the variable type. Can be ``character``, ``integer``, ``real``, ``complex``, ``logical``, ``ddt``, or a custom type defined by the host. Custom types should be listed under ``TYPEDEFS_NEW_METADATA`` in the prebuild configuration file.
+* ``type`` indicates the variable type. Can be ``character``, ``integer``, ``real``, ``complex``, ``logical``, ``ddt``, or a custom type defined by the host. Custom types must be listed under ``TYPEDEFS_NEW_METADATA`` in the prebuild configuration file.
 
-* ``kind`` (*optional*) indicates the variable kind, i.e. precision. The valid kinds are described in the file `physics/hooks/machine.F <https://github.com/NCAR/ccpp-physics/blob/main/physics/hooks/machine.F>`__.
+* ``kind`` (*optional*) indicates the variable kind, i.e. precision. The valid kinds are defined in the file `physics/hooks/machine.F <https://github.com/NCAR/ccpp-physics/blob/main/physics/hooks/machine.F>`__.
 
 * ``intent`` indicates the argument intent for the given variable. Can be ``in``, ``out``, or ``inout``.
 

--- a/CCPPtechnical/source/HostSideCoding.rst
+++ b/CCPPtechnical/source/HostSideCoding.rst
@@ -40,7 +40,7 @@ and :ref:`Listing 6.2 <example_vardefs_meta>` for examples of host model metadat
 
 * The ``standard_name`` must match that of the target variable in the physics scheme.
 * The type, kind, shape and size of the variable (as defined in the host model Fortran code) must match that of the target variable.
-* The attributes ``units``, ``rank``, ``type`` and ``kind`` in the host model metadata must match those in the physics scheme metadata.
+* The attributes ``units``, ``dimensions``, ``type`` and ``kind`` in the host model metadata must match those in the physics scheme metadata.
 * The attribute ``active`` is used to allocate variables under certain conditions.  It must be written as a Fortran expression that equates to ``.true.`` or ``.false.``, using the CCPP standard names of variables. ``active`` attributes for all variables are ``.true.`` by default. See :numref:`Section %s <ActiveAttribute>` for details.
 * The ``intent`` attribute is not a valid attribute for host model metadata and will be ignored, if present.
 * The ``local_name`` of the variable must be set to the name the host model cap uses to refer to the variable.

--- a/CCPPtechnical/source/_static/scheme_template.meta
+++ b/CCPPtechnical/source/_static/scheme_template.meta
@@ -8,13 +8,22 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 [ccpp-table-properties]
-  name = ozphys
+  name = drag_suite
   type = scheme
-  dependencies = machine.F
+  dependencies = ../hooks/machine.F
 
+########################################################################
 [ccpp-arg-table]
-  name = ozphys_run
+  name = drag_suite_init
   type = scheme
+[gwd_opt]
+  standard_name = control_for_drag_suite_gravity_wave_drag
+  long_name = flag to choose gwd scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = T
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
@@ -23,7 +32,6 @@
   type = character
   kind = len=*
   intent = out
-  optional = F
 [errflg]
   standard_name = ccpp_error_code
   long_name = error code for error handling in CCPP
@@ -31,4 +39,3 @@
   dimensions = ()
   type = integer
   intent = out
-  optional = F


### PR DESCRIPTION
This PR updates the metadata argument table rules, specifically to include definitions of all the entries including `long_name`. In updating this section I noticed that several other things were out-of-date, including

 - References to deprecated `rank` option
 - Outdated rule that order of arguments must match
 - Example CCPP prebuild error messages

All of these have been updated accordingly.