### PR TITLE
Adding automated Readthedocs link to open PRs

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,16 @@
+name: readthedocs/actions
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "readthedocs-preview"


### PR DESCRIPTION
It appears as if something has changed in the past year regarding readthedocs builds...it now requires a github action to get a link for open PRs. This PR adds that action.